### PR TITLE
角速度の送受信の際の定数倍のズレの補正

### DIFF
--- a/test/linux/cat_test_4/get.h
+++ b/test/linux/cat_test_4/get.h
@@ -21,6 +21,7 @@ double get_angular_vel(uint8* motor_data)
 {
     double act_angl_vel;
     act_angl_vel = ((int16)(motor_data[3] + ((uint16)(motor_data[4]) << 8))) / 256.0 * 2 * M_PI;
+    act_angl_vel = act_angl_vel / 2; // 2倍になっているので補正する
     return act_angl_vel;
 }
 

--- a/test/linux/cat_test_4/set.h
+++ b/test/linux/cat_test_4/set.h
@@ -97,11 +97,12 @@ void set_torque(double tor, uint8* cmdbuf)
 /*指令速度セット(-804.0から804.0まで)*/
 void set_speed(double spd, uint8* cmdbuf)
 {
-    if (spd < -804.0 || spd > 804.0) {
+    double spd_corrected = spd * 2.0;
+    if (spd_corrected < -804.0 || spd_corrected > 804.0) {
         printf("invalid speed\n");
         return;
     }
-    int16 spd_int = (int16)(spd * 256.0 / (2 * M_PI));
+    int16 spd_int = (int16)(spd_corrected * 256.0 / (2 * M_PI));
     cmdbuf[4] = (spd_int >> 8);
     cmdbuf[3] = spd_int & 0x00ff;
 }

--- a/test/linux/cat_test_4/set.h
+++ b/test/linux/cat_test_4/set.h
@@ -97,7 +97,7 @@ void set_torque(double tor, uint8* cmdbuf)
 /*指令速度セット(-804.0から804.0まで)*/
 void set_speed(double spd, uint8* cmdbuf)
 {
-    double spd_corrected = spd * 2.0;
+    double spd_corrected = spd * 2.0; // 速度が1/2になるので補正
     if (spd_corrected < -804.0 || spd_corrected > 804.0) {
         printf("invalid speed\n");
         return;

--- a/test/linux/proxima_robot/get.h
+++ b/test/linux/proxima_robot/get.h
@@ -21,6 +21,7 @@ double get_angular_vel(uint8* motor_data)
 {
     double act_angl_vel;
     act_angl_vel = ((int16)(motor_data[3] + ((uint16)(motor_data[4]) << 8))) / 256.0 * 2 * M_PI;
+    act_angl_vel = act_angl_vel / 2; // 2倍になっているので補正する
     return act_angl_vel;
 }
 

--- a/test/linux/proxima_robot/set.h
+++ b/test/linux/proxima_robot/set.h
@@ -97,11 +97,12 @@ void set_torque(double tor, uint8* cmdbuf)
 /*指令速度セット(-804.0から804.0まで)*/
 void set_speed(double spd, uint8* cmdbuf)
 {
-    if (spd < -804.0 || spd > 804.0) {
+    double spd_corrected = spd * 2.0; // 速度が1/2になるので補正
+    if (spd_corrected < -804.0 || spd_corrected > 804.0) {
         printf("invalid speed\n");
         return;
     }
-    int16 spd_int = (int16)(spd * 256.0 / (2 * M_PI));
+    int16 spd_int = (int16)(spd_corrected * 256.0 / (2 * M_PI));
     cmdbuf[4] = (spd_int >> 8);
     cmdbuf[3] = spd_int & 0x00ff;
 }


### PR DESCRIPTION
# 生じていた問題
- cat_test_4を用いて角速度を送受信すると、送信した指令値の0.5倍の速度でGo motorが回転し、実際の回転速度の2倍の速度測定値を返していた。
- [unitree-actuator-sdk][linkref]を用いて制御した場合と比較することでこの不具合を確認した。（それぞれ同じ角速度に設定して回転させようとすると、cat_test_4では1/2の速度で回転した。また受信側では、見た目上の速度の2倍の速度測定値を返した）

[linkref]: https://github.com/unitreerobotics/unitree_actuator_sdk/tree/GO-M8010-6 "unitree"
# 修正点
送受信用関数を修正した