### PR TITLE
速度ゲインの送信の際の定数倍のズレの補正

### DIFF
--- a/test/linux/cat_test_4/set.h
+++ b/test/linux/cat_test_4/set.h
@@ -130,11 +130,12 @@ void set_K_P(double k_p, uint8* cmdbuf)
 
 void set_K_W(double k_w, uint8* cmdbuf)
 {
-    if (k_w < 0 || k_w > 25.599) {
+    double k_w_corrected = k_w / 2.0; // 2倍になるので補正
+    if (k_w_corrected < 0 || k_w_corrected > 25.599) {
         printf("invalid k_w\n");
         return;
     }
-    int16 k_w_int = (int16)(k_w * 1280);
+    int16 k_w_int = (int16)(k_w_corrected * 1280);
     cmdbuf[12] = k_w_int >> 8;
     cmdbuf[11] = k_w_int & 0x00ff;
 }

--- a/test/linux/proxima_robot/set.h
+++ b/test/linux/proxima_robot/set.h
@@ -130,11 +130,12 @@ void set_K_P(double k_p, uint8* cmdbuf)
 
 void set_K_W(double k_w, uint8* cmdbuf)
 {
-    if (k_w < 0 || k_w > 25.599) {
+    double k_w_corrected = k_w / 2.0; // 2倍になるので補正
+    if (k_w_corrected < 0 || k_w_corrected > 25.599) {
         printf("invalid k_w\n");
         return;
     }
-    int16 k_w_int = (int16)(k_w * 1280);
+    int16 k_w_int = (int16)(k_w_corrected * 1280);
     cmdbuf[12] = k_w_int >> 8;
     cmdbuf[11] = k_w_int & 0x00ff;
 }


### PR DESCRIPTION
# 生じていた問題
- cat_test_4、proxima_robotを用いて速度を送受信すると、送信した指令値の2倍の速度ゲインで制御が行われていた。
- [unitree-actuator-sdk][linkref]を用いて制御した場合と比較することでこの不具合を確認した。kd=0.02、W=3.14 rad/s、T=1N・mで制御を行い、WとTそれぞれの偏差を比較するとわかりやすい。
 
以下がunitree-actuator-sdkを用いた場合の偏差の例で、
![image](https://github.com/user-attachments/assets/436e9fce-53bf-4d5a-8de7-bbd5f51922cc)
![image](https://github.com/user-attachments/assets/2d4920f0-c7e2-49ff-ae2e-b4547f49515c)
以下がSOEMのcat_test_4を用いたもの。
![image](https://github.com/user-attachments/assets/19d349ad-4943-41d4-be3e-0cabe72bae89)
![image](https://github.com/user-attachments/assets/5bd497b0-69e2-4047-9f2f-e3117486fe23)

Wの偏差が2倍ほどずれた値に収束している様子が確認された。

[linkref]: https://github.com/unitreerobotics/unitree_actuator_sdk/tree/GO-M8010-6 "unitree"
# 修正点
送信用関数を修正した。
kdを1/2にする処理を追加することで、unitree-actuator-sdkとSOEMで偏差が一致した。