### PR TITLE
トルクの設定値を減速比のぶんだけ補正

### DIFF
--- a/test/linux/proxima_robot/proxima_robot.cpp
+++ b/test/linux/proxima_robot/proxima_robot.cpp
@@ -337,7 +337,7 @@ void simpletest(char* ifname)
                             /*指令値セット*/
                             #if (ENABLE_LEGMOTOR == 1)
                             set_mode(1, motor[i].send);
-                            set_torque(total_control, motor[i].send);
+                            set_torque(total_control / 6.33, motor[i].send);
                             // set_torque(0, motor[i].send);
                             set_speed(0, motor[i].send);
                             set_K_P(0, motor[i].send);


### PR DESCRIPTION
# 発生していた問題
proxima_robotにてトルクの設定値を減速比6.33で割っていなかったため、actuator-trial-runなどを動かそうとする際に動作が不安定化していた。

unitree-actuator-sdkを用いて[actuator_trial_run](https://github.com/proxima-technology/small_nimbus_ws/tree/master/real_robot_control)を動かすと、トルクの指令値と観測値は以下のようになる。なお、データは[robot_logger](https://github.com/proxima-technology/small_nimbus_ws/tree/master/robot_logger)にて示された方法で取得できる。

![image](https://github.com/user-attachments/assets/7838d19f-66e4-40d8-bc60-80c9b34a1daa)

対してproxima-robotを用いると、以下のようになり、トルクの値が間違っていることがわかる。

![image](https://github.com/user-attachments/assets/f034e7a8-c0c4-4a0a-84b6-e1d9238efe2a)

# 解決
proxima-robotにてトルクの設定値の補正を行った。
