### PR TITLE
EtherCAT通信プログラムにおけるハイブリッド制御機能を搭載

### DIFF
--- a/test/linux/proxima_robot/proxima_robot.cpp
+++ b/test/linux/proxima_robot/proxima_robot.cpp
@@ -298,6 +298,10 @@ void simpletest(char* ifname)
                 float tor = 0;
                 float tor2 = 0;
                 struct timespec t_st[MOTOR_NUM], t_end[MOTOR_NUM];
+                double runtime_offset_pos[MOTOR_NUM];
+                for (int j = 0; j < MOTOR_NUM; j++) {
+                    runtime_offset_pos[j] = 0.0;
+                }
 
                 /* cyclic loop */
                 for (;;) {
@@ -314,15 +318,16 @@ void simpletest(char* ifname)
 
                             double torque_control = legmotor_command_shared[TORQUE_CMD_IDX*NUM_LEGMOTOR + i];
                             // TODO: 位置制御モードの実装
-                            /*
-                            double position_control_ratio = legmotor_command_shared[POSITION_CONTROL_MODE_RATIO_IDX*NUM_LEGMOTOR + i]; // [0,1] // 0 is using torque contol, 1 is using position control.
+                            
+                            //double position_control_ratio = legmotor_command_shared[POSITION_CONTROL_MODE_RATIO_IDX*NUM_LEGMOTOR + i]; // [0,1] // 0 is using torque contol, 1 is using position control.
                             double target_pos = legmotor_command_shared[POSITION_TARGET_IDX*NUM_LEGMOTOR + i];
+                            double target_vel = legmotor_command_shared[VELOCITY_TARGET_IDX*NUM_LEGMOTOR + i];
                             double kp = legmotor_command_shared[P_GAIN_IDX*NUM_LEGMOTOR + i];
                             double kd = legmotor_command_shared[D_GAIN_IDX*NUM_LEGMOTOR + i];
-                            double ki = legmotor_command_shared[I_GAIN_IDX*NUM_LEGMOTOR + i];
-                            double position_control = - kp*(measured_pos-target_pos) - kd*measured_vel; // todo: implement I control
-                            double total_control = (1.0 - position_control_ratio) * torque_control + position_control_ratio * position_control;
-                            */
+                            //double ki = legmotor_command_shared[I_GAIN_IDX*NUM_LEGMOTOR + i];
+                            //double position_control = - kp*(measured_pos-target_pos) - kd*measured_vel; // todo: implement I control
+                            //double total_control = (1.0 - position_control_ratio) * torque_control + position_control_ratio * position_control;
+                            
                             double total_control = torque_control;
 
                             double torque_max = 23.5;
@@ -332,17 +337,18 @@ void simpletest(char* ifname)
                             if(1==i)
                             {
                               total_control = - total_control;
+                              target_pos = - target_pos; 
+                              target_vel = - target_vel;
                             }
 
                             /*指令値セット*/
                             #if (ENABLE_LEGMOTOR == 1)
                             set_mode(1, motor[i].send);
                             set_torque(total_control / 6.33, motor[i].send);
-                            // set_torque(0, motor[i].send);
-                            set_speed(0, motor[i].send);
-                            set_K_P(0, motor[i].send);
-                            set_K_W(0, motor[i].send);
-                            set_position(0, motor[i].send);
+                            set_position((target_pos - runtime_offset_pos[i]) * 6.33, motor[i].send);
+                            set_speed(target_vel * 6.33, motor[i].send);
+                            set_K_P(kp / ( 6.33 * 6.33 ), motor[i].send);
+                            set_K_W(kd / ( 6.33 * 6.33 ), motor[i].send);
                             /***********************/
                             // st_clock[i] = clock();
                             clock_gettime(CLOCK_MONOTONIC, &t_st[i]);
@@ -379,6 +385,7 @@ void simpletest(char* ifname)
                                     {
                                       while(1)
                                       {
+                                        runtime_offset_pos[cnt] = pos_offset[cnt] + runtime_offset_rotation_count[cnt]*2*M_PI/6.33;
                                         legmotor_sensor_shared[POSITION_OBS_IDX*NUM_LEGMOTOR + cnt] = pos_offset[cnt] + raw_position / 6.33 + runtime_offset_rotation_count[cnt]*2*M_PI/6.33;
                                         if(std::abs(legmotor_sensor_shared[cnt])<(-1e-6 + M_PI/6.33))
                                         {

--- a/test/linux/proxima_robot/proxima_robot.cpp
+++ b/test/linux/proxima_robot/proxima_robot.cpp
@@ -317,26 +317,18 @@ void simpletest(char* ifname)
                             motor[i].send[15] = check[i];
 
                             double torque_control = legmotor_command_shared[TORQUE_CMD_IDX*NUM_LEGMOTOR + i];
-                            // TODO: 位置制御モードの実装
-                            
-                            //double position_control_ratio = legmotor_command_shared[POSITION_CONTROL_MODE_RATIO_IDX*NUM_LEGMOTOR + i]; // [0,1] // 0 is using torque contol, 1 is using position control.
                             double target_pos = legmotor_command_shared[POSITION_TARGET_IDX*NUM_LEGMOTOR + i];
                             double target_vel = legmotor_command_shared[VELOCITY_TARGET_IDX*NUM_LEGMOTOR + i];
                             double kp = legmotor_command_shared[P_GAIN_IDX*NUM_LEGMOTOR + i];
                             double kd = legmotor_command_shared[D_GAIN_IDX*NUM_LEGMOTOR + i];
-                            //double ki = legmotor_command_shared[I_GAIN_IDX*NUM_LEGMOTOR + i];
-                            //double position_control = - kp*(measured_pos-target_pos) - kd*measured_vel; // todo: implement I control
-                            //double total_control = (1.0 - position_control_ratio) * torque_control + position_control_ratio * position_control;
                             
-                            double total_control = torque_control;
-
                             double torque_max = 23.5;
-                            total_control = std::max(-torque_max, std::min(torque_max, total_control));
+                            torque_control = std::max(-torque_max, std::min(torque_max, torque_control));
 
                             // reverse just before send
                             if(1==i)
                             {
-                              total_control = - total_control;
+                              torque_control = - torque_control;
                               target_pos = - target_pos; 
                               target_vel = - target_vel;
                             }
@@ -344,7 +336,7 @@ void simpletest(char* ifname)
                             /*指令値セット*/
                             #if (ENABLE_LEGMOTOR == 1)
                             set_mode(1, motor[i].send);
-                            set_torque(total_control / 6.33, motor[i].send);
+                            set_torque(torque_control / 6.33, motor[i].send);
                             set_position((target_pos - runtime_offset_pos[i]) * 6.33, motor[i].send);
                             set_speed(target_vel * 6.33, motor[i].send);
                             set_K_P(kp / ( 6.33 * 6.33 ), motor[i].send);


### PR DESCRIPTION
# 行ったこと
[unitree_actuator_sdk](https://github.com/proxima-technology/unitree_actuator_sdk/blob/ceb0ae5bcfe2b1ee8e65db68072be6eaa1fc24e3/example/main.cpp)にて行っていたハイブリッド制御をSOEMのproxima_robotプログラムで実装し、actuator_tiral_runのハイブリッド制御（[control_modeが2の状態](https://github.com/proxima-technology/small_nimbus_ws/blob/master/control_system/control_system_actuator_trial_run.cpp#L13))を行ったところ、正常に近い動作が確認された。

# 残る問題点
意図したことかどうかはわかりませんが、unitree_actuator_sdkとSOEMのproxima_robotでオフセットに差があるような気がします。具体的に以下に記します。

rosbagを用いてそれぞれの動作を確認したところ、unitree_actuator_sdk（上図）とSOEM（下図）のPositionに0.05の差が見られた。

![image](https://github.com/user-attachments/assets/bdd6e076-0519-4297-8c6e-c8ad0dcd6d3a)

![image](https://github.com/user-attachments/assets/353eff5c-1c9a-4149-951c-97dd3557d69f)

原因は調査中です。